### PR TITLE
Feature: Disable overlay while in the olm room.

### DIFF
--- a/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
@@ -178,10 +178,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
+			position = 13,
 			keyName = "hideOverlayInOlm",
 			name = "Hide overlay in Olm Room",
-			description = "Do not show overlay while in olm",
-			position = 13
+			description = "Do not show overlay while in olm"
 	)
 	default boolean hideInOlm() {
 		return true;

--- a/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
@@ -35,10 +35,10 @@ import java.awt.Color;
 public interface CoxScouterExternalConfig extends Config
 {
 	@ConfigItem(
-			position = 0,
-			keyName = "showTutorialOverlay",
-			name = "Show tutorial overlay",
-			description = "Whether to show an overlay to help understand how to use the plugin"
+		position = 0,
+		keyName = "showTutorialOverlay",
+		name = "Show tutorial overlay",
+		description = "Whether to show an overlay to help understand how to use the plugin"
 	)
 	default boolean showTutorialOverlay()
 	{
@@ -46,10 +46,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 1,
-			keyName = "scoutOverlay",
-			name = "Show scout overlay",
-			description = "Display an overlay that shows the current raid layout (when entering lobby)"
+		position = 1,
+		keyName = "scoutOverlay",
+		name = "Show scout overlay",
+		description = "Display an overlay that shows the current raid layout (when entering lobby)"
 	)
 	default boolean scoutOverlay()
 	{
@@ -57,10 +57,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 2,
-			keyName = "displayFloorBreak",
-			name = "Layout floor break",
-			description = "Displays floor break in layout"
+		position = 2,
+		keyName = "displayFloorBreak",
+		name = "Layout floor break",
+		description = "Displays floor break in layout"
 	)
 	default boolean displayFloorBreak()
 	{
@@ -68,10 +68,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 3,
-			keyName = "screenshotHotkey",
-			name = "Scouter screenshot hotkey",
-			description = "Hotkey used to screenshot the scouting overlay"
+		position = 3,
+		keyName = "screenshotHotkey",
+		name = "Scouter screenshot hotkey",
+		description = "Hotkey used to screenshot the scouting overlay"
 	)
 	default Keybind screenshotHotkey()
 	{
@@ -79,10 +79,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 4,
-			keyName = "showRecommendedItems",
-			name = "Show recommended items",
-			description = "Adds overlay with recommended items to scouter"
+		position = 4,
+		keyName = "showRecommendedItems",
+		name = "Show recommended items",
+		description = "Adds overlay with recommended items to scouter"
 	)
 	default boolean showRecommendedItems()
 	{
@@ -90,10 +90,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 5,
-			keyName = "recommendedItems",
-			name = "Recommended items",
-			description = "User-set recommended items in the form: [muttadiles,ice barrage,zamorak godsword],[tekton,elder maul], ..."
+		position = 5,
+		keyName = "recommendedItems",
+		name = "Recommended items",
+		description = "User-set recommended items in the form: [muttadiles,ice barrage,zamorak godsword],[tekton,elder maul], ..."
 	)
 	default String recommendedItems()
 	{
@@ -101,10 +101,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 6,
-			keyName = "highlightedRooms",
-			name = "Highlighted rooms",
-			description = "Display highlighted rooms in a different color on the overlay. Separate with comma (full name)"
+		position = 6,
+		keyName = "highlightedRooms",
+		name = "Highlighted rooms",
+		description = "Display highlighted rooms in a different color on the overlay. Separate with comma (full name)"
 	)
 	default String highlightedRooms()
 	{
@@ -112,10 +112,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 7,
-			keyName = "highlightColor",
-			name = "Highlight color",
-			description = "The color of highlighted rooms"
+		position = 7,
+		keyName = "highlightColor",
+		name = "Highlight color",
+		description = "The color of highlighted rooms"
 	)
 	default Color highlightColor()
 	{
@@ -123,10 +123,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 8,
-			keyName = "hideMissingHighlighted",
-			name = "Hide missing highlighted",
-			description = "Completely hides raids missing highlighted room(s)"
+		position = 8,
+		keyName = "hideMissingHighlighted",
+		name = "Hide missing highlighted",
+		description = "Completely hides raids missing highlighted room(s)"
 	)
 	default boolean hideMissingHighlighted()
 	{
@@ -134,10 +134,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 9,
-			keyName = "highlightedShowThreshold",
-			name = "Show threshold",
-			description = "The number of highlighted rooms needed to show the raid. 0 means no threshold."
+		position = 9,
+		keyName = "highlightedShowThreshold",
+		name = "Show threshold",
+		description = "The number of highlighted rooms needed to show the raid. 0 means no threshold."
 	)
 	default int highlightedShowThreshold()
 	{
@@ -145,10 +145,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 10,
-			keyName = "hideBlacklist",
-			name = "Hide raids with blacklisted",
-			description = "Completely hides raids containing blacklisted room(s)"
+		position = 10,
+		keyName = "hideBlacklist",
+		name = "Hide raids with blacklisted",
+		description = "Completely hides raids containing blacklisted room(s)"
 	)
 	default boolean hideBlacklisted()
 	{
@@ -156,10 +156,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 11,
-			keyName = "hideMissingLayout",
-			name = "Hide missing layout",
-			description = "Completely hides raids missing a whitelisted layout"
+		position = 11,
+		keyName = "hideMissingLayout",
+		name = "Hide missing layout",
+		description = "Completely hides raids missing a whitelisted layout"
 	)
 	default boolean hideMissingLayout()
 	{
@@ -167,10 +167,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 12,
-			keyName = "hideRopeless",
-			name = "Hide ropeless raids",
-			description = "Completely hides raids missing a tightrope"
+		position = 12,
+		keyName = "hideRopeless",
+		name = "Hide ropeless raids",
+		description = "Completely hides raids missing a tightrope"
 	)
 	default boolean hideRopeless()
 	{
@@ -178,10 +178,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 13,
-			keyName = "hideOverlayInOlm",
-			name = "Hide overlay in Olm Room",
-			description = "Do not show overlay while in olm"
+		position = 13,
+		keyName = "hideOverlayInOlm",
+		name = "Hide overlay in Olm Room",
+		description = "Do not show overlay while in olm"
 	)
 	default boolean hideInOlm() {
 		return true;

--- a/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
@@ -31,7 +31,7 @@ import net.runelite.client.config.Keybind;
 
 import java.awt.Color;
 
-@ConfigGroup("coxscouterexternalplus")
+@ConfigGroup("coxscouterexternal")
 public interface CoxScouterExternalConfig extends Config
 {
 	@ConfigItem(

--- a/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
@@ -180,7 +180,7 @@ public interface CoxScouterExternalConfig extends Config
 	@ConfigItem(
 		position = 13,
 		keyName = "hideOverlayInOlm",
-		name = "Hide overlay in Olm Room",
+		name = "Hide overlay in olm room",
 		description = "Do not show overlay while in olm"
 	)
 	default boolean hideInOlm() {

--- a/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
@@ -31,14 +31,14 @@ import net.runelite.client.config.Keybind;
 
 import java.awt.Color;
 
-@ConfigGroup("coxscouterexternal")
+@ConfigGroup("coxscouterexternalplus")
 public interface CoxScouterExternalConfig extends Config
 {
 	@ConfigItem(
-		position = 0,
-		keyName = "showTutorialOverlay",
-		name = "Show tutorial overlay",
-		description = "Whether to show an overlay to help understand how to use the plugin"
+			position = 0,
+			keyName = "showTutorialOverlay",
+			name = "Show tutorial overlay",
+			description = "Whether to show an overlay to help understand how to use the plugin"
 	)
 	default boolean showTutorialOverlay()
 	{
@@ -46,10 +46,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 1,
-		keyName = "scoutOverlay",
-		name = "Show scout overlay",
-		description = "Display an overlay that shows the current raid layout (when entering lobby)"
+			position = 1,
+			keyName = "scoutOverlay",
+			name = "Show scout overlay",
+			description = "Display an overlay that shows the current raid layout (when entering lobby)"
 	)
 	default boolean scoutOverlay()
 	{
@@ -57,10 +57,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
-		keyName = "displayFloorBreak",
-		name = "Layout floor break",
-		description = "Displays floor break in layout"
+			position = 2,
+			keyName = "displayFloorBreak",
+			name = "Layout floor break",
+			description = "Displays floor break in layout"
 	)
 	default boolean displayFloorBreak()
 	{
@@ -68,10 +68,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
-		keyName = "screenshotHotkey",
-		name = "Scouter screenshot hotkey",
-		description = "Hotkey used to screenshot the scouting overlay"
+			position = 3,
+			keyName = "screenshotHotkey",
+			name = "Scouter screenshot hotkey",
+			description = "Hotkey used to screenshot the scouting overlay"
 	)
 	default Keybind screenshotHotkey()
 	{
@@ -79,10 +79,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
-		keyName = "showRecommendedItems",
-		name = "Show recommended items",
-		description = "Adds overlay with recommended items to scouter"
+			position = 4,
+			keyName = "showRecommendedItems",
+			name = "Show recommended items",
+			description = "Adds overlay with recommended items to scouter"
 	)
 	default boolean showRecommendedItems()
 	{
@@ -90,10 +90,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
-		keyName = "recommendedItems",
-		name = "Recommended items",
-		description = "User-set recommended items in the form: [muttadiles,ice barrage,zamorak godsword],[tekton,elder maul], ..."
+			position = 5,
+			keyName = "recommendedItems",
+			name = "Recommended items",
+			description = "User-set recommended items in the form: [muttadiles,ice barrage,zamorak godsword],[tekton,elder maul], ..."
 	)
 	default String recommendedItems()
 	{
@@ -101,10 +101,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
-		keyName = "highlightedRooms",
-		name = "Highlighted rooms",
-		description = "Display highlighted rooms in a different color on the overlay. Separate with comma (full name)"
+			position = 6,
+			keyName = "highlightedRooms",
+			name = "Highlighted rooms",
+			description = "Display highlighted rooms in a different color on the overlay. Separate with comma (full name)"
 	)
 	default String highlightedRooms()
 	{
@@ -112,10 +112,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
-		keyName = "highlightColor",
-		name = "Highlight color",
-		description = "The color of highlighted rooms"
+			position = 7,
+			keyName = "highlightColor",
+			name = "Highlight color",
+			description = "The color of highlighted rooms"
 	)
 	default Color highlightColor()
 	{
@@ -123,10 +123,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
-		keyName = "hideMissingHighlighted",
-		name = "Hide missing highlighted",
-		description = "Completely hides raids missing highlighted room(s)"
+			position = 8,
+			keyName = "hideMissingHighlighted",
+			name = "Hide missing highlighted",
+			description = "Completely hides raids missing highlighted room(s)"
 	)
 	default boolean hideMissingHighlighted()
 	{
@@ -134,10 +134,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
-		keyName = "highlightedShowThreshold",
-		name = "Show threshold",
-		description = "The number of highlighted rooms needed to show the raid. 0 means no threshold."
+			position = 9,
+			keyName = "highlightedShowThreshold",
+			name = "Show threshold",
+			description = "The number of highlighted rooms needed to show the raid. 0 means no threshold."
 	)
 	default int highlightedShowThreshold()
 	{
@@ -145,10 +145,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
-		keyName = "hideBlacklist",
-		name = "Hide raids with blacklisted",
-		description = "Completely hides raids containing blacklisted room(s)"
+			position = 10,
+			keyName = "hideBlacklist",
+			name = "Hide raids with blacklisted",
+			description = "Completely hides raids containing blacklisted room(s)"
 	)
 	default boolean hideBlacklisted()
 	{
@@ -156,10 +156,10 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
-		keyName = "hideMissingLayout",
-		name = "Hide missing layout",
-		description = "Completely hides raids missing a whitelisted layout"
+			position = 11,
+			keyName = "hideMissingLayout",
+			name = "Hide missing layout",
+			description = "Completely hides raids missing a whitelisted layout"
 	)
 	default boolean hideMissingLayout()
 	{
@@ -167,13 +167,23 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
-		keyName = "hideRopeless",
-		name = "Hide ropeless raids",
-		description = "Completely hides raids missing a tightrope"
+			position = 12,
+			keyName = "hideRopeless",
+			name = "Hide ropeless raids",
+			description = "Completely hides raids missing a tightrope"
 	)
 	default boolean hideRopeless()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+			keyName = "hideOverlayInOlm",
+			name = "Hide overlay in Olm Room",
+			description = "Do not show overlay while in olm",
+			position = 13
+	)
+	default boolean hideInOlm() {
+		return true;
 	}
 }

--- a/src/main/java/bbp/chambers/CoxScouterExternalOverlay.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalOverlay.java
@@ -71,6 +71,8 @@ public class CoxScouterExternalOverlay extends OverlayPanel
 	private static final int BORDER_OFFSET = 2;
 	private static final int ICON_SIZE = 32;
 	private static final int SMALL_ICON_SIZE = 21;
+	private static final int OLM_PLANE = 0;
+	private static final int OLM_X = 3200, OLM_X2 = 3263, OLM_Y = 5697, OLM_Y2 = 5759;
 
 	private final Client client;
 	private final CoxScouterExternalPlugin plugin;
@@ -144,8 +146,8 @@ public class CoxScouterExternalOverlay extends OverlayPanel
 		boolean olm = false;
 		if (config.hideInOlm()) {
 			WorldPoint location = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation());
-			olm = location.getPlane() == 0 && location.getX() >= 3200 && location.getX() <= 3263 &&
-					location.getY() >= 5697 && location.getY() <= 5759;
+			olm = location.getPlane() == OLM_PLANE && location.getX() >= OLM_X && location.getX() <= OLM_X2 &&
+					location.getY() >= OLM_Y && location.getY() <= OLM_Y2;
 		}
 
 		if (olm) {

--- a/src/main/java/bbp/chambers/CoxScouterExternalOverlay.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalOverlay.java
@@ -40,6 +40,7 @@ import static net.runelite.api.MenuAction.RUNELITE_OVERLAY;
 import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
 
 import net.runelite.api.SpriteID;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
@@ -138,6 +139,17 @@ public class CoxScouterExternalOverlay extends OverlayPanel
 		if (enabledWhitelist && !plugin.getLayoutWhitelist().contains(layout.toLowerCase()))
 		{
 			color = Color.RED;
+		}
+
+		boolean olm = false;
+		if (config.hideInOlm()) {
+			WorldPoint location = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation());
+			olm = location.getPlane() == 0 && location.getX() >= 3200 && location.getX() <= 3263 &&
+					location.getY() >= 5697 && location.getY() <= 5759;
+		}
+
+		if (olm) {
+			return null;
 		}
 
 		boolean hide = false;


### PR DESCRIPTION
This pull request adds the feature of disabling the overlay while in olm. The overlay doesn't do anything while in olm.
- Adds a config check called `hideInOlm`. This check is enabled by default.
- Checks if the client's local player is in the room on location between `x3200, x3263` `y5697, y5759` ([explv Map](https://explv.github.io/?centreX=3200&centreY=5760&centreZ=0&zoom=9)). There is probably an easier way to check if the local player is in the olm room.
 
![image](https://github.com/user-attachments/assets/75f1f9b8-87a6-4c9c-ad2e-760f6480117c)
