### PR TITLE
Adding supplies to overlay

### DIFF
--- a/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
@@ -102,6 +102,14 @@ public interface CoxScouterExternalConfig extends Config
 
 	@ConfigItem(
 		position = 6,
+		keyName = "showSupplies",
+		name = "Show Supplies",
+		description = "Shows dropped supplies from scouted rooms for no-prep planning"
+	)
+	default boolean showSupplies() { return false; }
+
+	@ConfigItem(
+		position = 7,
 		keyName = "highlightedRooms",
 		name = "Highlighted rooms",
 		description = "Display highlighted rooms in a different color on the overlay. Separate with comma (full name)"
@@ -112,7 +120,7 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 8,
 		keyName = "highlightColor",
 		name = "Highlight color",
 		description = "The color of highlighted rooms"
@@ -123,7 +131,7 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 9,
 		keyName = "hideMissingHighlighted",
 		name = "Hide missing highlighted",
 		description = "Completely hides raids missing highlighted room(s)"
@@ -134,7 +142,7 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 10,
 		keyName = "highlightedShowThreshold",
 		name = "Show threshold",
 		description = "The number of highlighted rooms needed to show the raid. 0 means no threshold."
@@ -145,7 +153,7 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 11,
 		keyName = "hideBlacklist",
 		name = "Hide raids with blacklisted",
 		description = "Completely hides raids containing blacklisted room(s)"
@@ -156,7 +164,7 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 12,
 		keyName = "hideMissingLayout",
 		name = "Hide missing layout",
 		description = "Completely hides raids missing a whitelisted layout"
@@ -167,7 +175,7 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 13,
 		keyName = "hideRopeless",
 		name = "Hide ropeless raids",
 		description = "Completely hides raids missing a tightrope"

--- a/src/main/java/bbp/chambers/CoxScouterExternalOverlay.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalOverlay.java
@@ -32,6 +32,7 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.image.BufferedImage;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
 import net.runelite.api.FriendsChatManager;
@@ -112,6 +113,7 @@ public class CoxScouterExternalOverlay extends OverlayPanel
 		boolean ccDisplay = configManager.getConfiguration("raids", "ccDisplay", Boolean.class);
 		boolean enabledWhitelist = configManager.getConfiguration("raids", "enableLayoutWhitelist", Boolean.class);
 		boolean rotationWhitelist = configManager.getConfiguration("raids", "enableRotationWhitelist", Boolean.class);
+		boolean showSupplies = config.showSupplies();
 
 		Color color = Color.WHITE;
 		String layout;
@@ -315,6 +317,45 @@ public class CoxScouterExternalOverlay extends OverlayPanel
 							.build());
 					break;
 			}
+		}
+
+		// add room supply drops
+		if (showSupplies)
+		{
+			Map<String, Integer> supplies = plugin.getDroppedSupplies();
+
+			panelComponent.getChildren().add(LineComponent.builder().build());
+
+			panelComponent.getChildren().add(TitleComponent.builder()
+				.text("Supply Drops")
+				.color(Color.ORANGE).build());
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left("Overloads:")
+				.right(Integer.toString(supplies.get("overloads")))
+				.leftColor(color)
+				.rightColor(color)
+				.build());
+
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left("Prayer Enhances:")
+				.right(Integer.toString(supplies.get("prayer_enhances")))
+				.leftColor(color)
+				.rightColor(color)
+				.build());
+
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left("Xeric Aids:")
+				.right(Integer.toString(supplies.get("aids")))
+				.rightColor(color)
+				.leftColor(color)
+				.build());
+
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left("Revitilizations:")
+				.right(Integer.toString(supplies.get("revitalizations")))
+				.leftColor(color)
+				.rightColor(color)
+				.build());
 		}
 
 		//add recommended items

--- a/src/main/java/bbp/chambers/CoxScouterExternalPlugin.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalPlugin.java
@@ -497,17 +497,7 @@ public class CoxScouterExternalPlugin extends Plugin
 			return;
 		}
 
-		Rectangle overlayDimensions;
-
-		if (droppedSupplies.isEmpty())
-		{
-			overlayDimensions = overlay.getBounds();
-		}
-		else
-		{
-			overlayDimensions = new Rectangle();
-			overlayDimensions.setBounds(overlay.getBounds().x, overlay.getBounds().y, overlay.getBounds().width, overlay.getBounds().height - 95);
-		}
+		Rectangle overlayDimensions = overlay.getBounds();
 
 		BufferedImage overlayImage = new BufferedImage(overlayDimensions.width, overlayDimensions.height, BufferedImage.TYPE_INT_RGB);
 		Graphics2D graphic = overlayImage.createGraphics();


### PR DESCRIPTION
Adds an option to display what supplies will drop during the raid to help with no-prep planning.

Example
<img width="139" height="232" alt="image" src="https://github.com/user-attachments/assets/208643d9-0fc6-4748-a2e1-1a1f8d6144a8" />
