### PR TITLE
Add option to highlight missing recommended items in bank

### DIFF
--- a/src/main/java/bbp/chambers/CoxScouterExternalBankOverlay.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalBankOverlay.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026, Truth Forger <https://github.com/Blackberry0Pie>
+ * Copyright (c) 2026, stutify <https://github.com/stutify>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package bbp.chambers;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.util.HashSet;
+import java.util.Set;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.gameval.InventoryID;
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.game.ItemVariationMapping;
+import net.runelite.client.ui.overlay.WidgetItemOverlay;
+
+public class CoxScouterExternalBankOverlay extends WidgetItemOverlay
+{
+	private final Client client;
+	private final CoxScouterExternalPlugin plugin;
+	private final CoxScouterExternalConfig config;
+	private int lastGameCycle = -1;
+	private Set<Integer> cachedPlayerItems;
+
+	@Inject
+	private CoxScouterExternalBankOverlay(Client client, CoxScouterExternalPlugin plugin, CoxScouterExternalConfig config)
+	{
+		this.client = client;
+		this.plugin = plugin;
+		this.config = config;
+		showOnBank();
+	}
+
+	@Override
+	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem) {
+		if (!config.highlightBankItems()) {
+			return;
+		}
+
+		if (!isRecommendedItem(itemId)) {
+			return;
+		}
+
+		if (playerHasItem(itemId)) {
+			return;
+		}
+
+		highlightItem(graphics, widgetItem);
+	}
+
+	private boolean isRecommendedItem(int itemId)
+	{
+		Set<Integer> recommendedIds = plugin.getRaidRecommendedItems();
+		if (recommendedIds.contains(itemId))
+		{
+			return true;
+		}
+
+		int baseId = ItemVariationMapping.map(itemId);
+		for (int recommendedId : recommendedIds)
+		{
+			if (ItemVariationMapping.map(recommendedId) == baseId)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean playerHasItem(int itemId)
+	{
+		Set<Integer> playerItems = getPlayerItems();
+		if (playerItems.contains(itemId))
+		{
+			return true;
+		}
+
+		int baseItemId = ItemVariationMapping.map(itemId);
+		for (int playerItemId : playerItems)
+		{
+			if (playerItemId != -1 && ItemVariationMapping.map(playerItemId) == baseItemId)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private Set<Integer> getPlayerItems()
+	{
+		int currentCycle = client.getGameCycle();
+		if (currentCycle == lastGameCycle && cachedPlayerItems != null)
+		{
+			// to avoid building a new set of player items for each banked item
+			return cachedPlayerItems;
+		}
+		lastGameCycle = currentCycle;
+		cachedPlayerItems = getPlayerItemIds();
+		return cachedPlayerItems;
+	}
+
+	private Set<Integer> getPlayerItemIds() {
+		Set<Integer> playerItemIds = new HashSet<>();
+		ItemContainer inventory = client.getItemContainer(InventoryID.INV);
+		if (inventory != null)
+		{
+			for (Item item : inventory.getItems())
+			{
+				playerItemIds.add(item.getId());
+			}
+		}
+
+		ItemContainer equipment = client.getItemContainer(InventoryID.WORN);
+		if (equipment != null)
+		{
+			for (Item item : equipment.getItems())
+			{
+				playerItemIds.add(item.getId());
+			}
+		}
+
+		return playerItemIds;
+	}
+
+	private void highlightItem(Graphics2D graphics, WidgetItem widgetItem) {
+		Rectangle bounds = widgetItem.getCanvasBounds();
+		if (bounds == null)
+		{
+			return;
+		}
+
+		Color color = config.highlightBankItemsColor();
+		graphics.setColor(color);
+		graphics.fill(bounds);
+	}
+}

--- a/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalConfig.java
@@ -28,6 +28,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Keybind;
+import net.runelite.client.config.Alpha;
 
 import java.awt.Color;
 
@@ -102,6 +103,29 @@ public interface CoxScouterExternalConfig extends Config
 
 	@ConfigItem(
 		position = 6,
+		keyName = "highlightBankItems",
+		name = "Highlight items in bank",
+		description = "Highlight recommended items in the bank"
+	)
+	default boolean highlightBankItems()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 7,
+		keyName = "highlightBankItemsColor",
+		name = "Highlight items in bank color",
+		description = "The color to highlight the recommended items in the bank with"
+	)
+	@Alpha
+	default Color highlightBankItemsColor()
+	{
+		return new Color(0, 255, 255, 50);
+	}
+
+	@ConfigItem(
+		position = 8,
 		keyName = "highlightedRooms",
 		name = "Highlighted rooms",
 		description = "Display highlighted rooms in a different color on the overlay. Separate with comma (full name)"
@@ -112,7 +136,7 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 9,
 		keyName = "highlightColor",
 		name = "Highlight color",
 		description = "The color of highlighted rooms"
@@ -123,7 +147,7 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 10,
 		keyName = "hideMissingHighlighted",
 		name = "Hide missing highlighted",
 		description = "Completely hides raids missing highlighted room(s)"
@@ -134,7 +158,7 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 11,
 		keyName = "highlightedShowThreshold",
 		name = "Show threshold",
 		description = "The number of highlighted rooms needed to show the raid. 0 means no threshold."
@@ -145,7 +169,7 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 12,
 		keyName = "hideBlacklist",
 		name = "Hide raids with blacklisted",
 		description = "Completely hides raids containing blacklisted room(s)"
@@ -156,7 +180,7 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 13,
 		keyName = "hideMissingLayout",
 		name = "Hide missing layout",
 		description = "Completely hides raids missing a whitelisted layout"
@@ -167,7 +191,7 @@ public interface CoxScouterExternalConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 14,
 		keyName = "hideRopeless",
 		name = "Hide ropeless raids",
 		description = "Completely hides raids missing a tightrope"

--- a/src/main/java/bbp/chambers/CoxScouterExternalPlugin.java
+++ b/src/main/java/bbp/chambers/CoxScouterExternalPlugin.java
@@ -64,7 +64,6 @@ import net.runelite.client.plugins.raids.solver.Room;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.HotkeyListener;
 import net.runelite.client.util.ImageCapture;
-import net.runelite.client.util.ImageUploadStyle;
 import net.runelite.client.util.Text;
 import net.runelite.client.party.PartyMember;
 import net.runelite.client.party.PartyService;
@@ -121,6 +120,9 @@ public class CoxScouterExternalPlugin extends Plugin
 	private CoxScouterExternalTutorialOverlay tutorialOverlay;
 
 	@Inject
+	private CoxScouterExternalBankOverlay bankOverlay;
+
+	@Inject
 	private ItemManager itemManager;
 
 	@Inject
@@ -171,6 +173,7 @@ public class CoxScouterExternalPlugin extends Plugin
 	{
 		overlayManager.add(overlay);
 		overlayManager.add(tutorialOverlay);
+		overlayManager.add(bankOverlay);
 		updateLists();
 		this.clientThread.invokeLater(this::checkRaidPresence);
 		keyManager.registerKeyListener(screenshotHotkeyListener);
@@ -181,6 +184,7 @@ public class CoxScouterExternalPlugin extends Plugin
 	{
 		overlayManager.remove(overlay);
 		overlayManager.remove(tutorialOverlay);
+		overlayManager.remove(bankOverlay);
 		inRaidChambers = false;
 		keyManager.unregisterKeyListener(screenshotHotkeyListener);
 	}
@@ -524,5 +528,32 @@ public class CoxScouterExternalPlugin extends Plugin
 		{
 			raidState = tempRaidState;
 		}
+	}
+
+	Set<Integer> getRaidRecommendedItems()
+	{
+		Set<Integer> itemIds = new HashSet<>();
+		if (raid == null || raid.getLayout() == null)
+		{
+			return itemIds;
+		}
+
+		for (Room layoutRoom : raid.getLayout().getRooms())
+		{
+			int position = layoutRoom.getPosition();
+			RaidRoom room = raid.getRoom(position);
+			if (room == null)
+			{
+				continue;
+			}
+
+			List<Integer> recommended = getRecommendedItemsList().get(room.getName().toLowerCase());
+			if (recommended != null)
+			{
+				itemIds.addAll(recommended);
+			}
+		}
+
+		return itemIds;
 	}
 }


### PR DESCRIPTION
Thanks for all the great work on this plugin! As a long time user I've had one gripe with it: whenever I find a suitable raid I have to memorize the list of items to withdraw before I open the bank, as the overlay is hidden by the bank interface once it's opened. This PR adds the option to highlight the missing recommended items in bank as well, so you don't have to keep closing the bank interface to have a peek at the recommended items.

![java_2026-03-15_13-22-04](https://github.com/user-attachments/assets/c552cd97-93fa-46ca-b9dc-ec6579f5b60d)
